### PR TITLE
09 10 12 controllers e testes

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -78,3 +78,4 @@ yarn-debug.log*
 
 # Rubymine .idea
 .idea/
+coverage

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -48,6 +48,7 @@ group :development do
   # gem "spring"
 end
 
+gem 'simplecov', require: false, group: :test
 
 gem "devise", "~> 4.8"
 gem "devise-jwt", "~> 0.9.0"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
       warden-jwt_auth (~> 0.6)
     diff-lcs (1.5.0)
     digest (3.1.0)
+    docile (1.4.0)
     dry-auto_inject (0.9.0)
       dry-container (>= 0.3.4)
     dry-configurable (0.14.0)
@@ -197,6 +198,12 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.11.0)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sqlite3 (1.4.2)
     strscan (3.0.1)
     thor (1.2.1)
@@ -229,6 +236,7 @@ DEPENDENCIES
   rack-cors (~> 1.1)
   rails (~> 7.0.2, >= 7.0.2.3)
   rspec-rails (~> 5.1.1)
+  simplecov
   sqlite3 (~> 1.4)
   tzinfo-data
 

--- a/backend/app/controllers/survey_answers_controller.rb
+++ b/backend/app/controllers/survey_answers_controller.rb
@@ -4,9 +4,20 @@ class SurveyAnswersController < ApplicationController
     survey_answers = SurveyAnswer.new(enrollment: enrollment, survey_id: params[:survey_id])
     survey_answers.save!
     params.require(:answers).each do |answer|
-      a = Answer.new(answer.permit(:survey_question_id, :content))
+      a = Answer.new(answer.permit(:survey_question_id, :content)) #(:selected_options, :custom_option)
       a.survey_answer_id = survey_answers.id
       a.save!
+      if a.survey_question.question_type == 'Caixa de Seleção'
+        options = answer.require(:selected_options).map(&:to_i)
+        custom_option = answer.require(:custom_option)
+
+        options.each do |option|
+          SelectedOption.create(option_id: option, answer_id: a.id)
+        end
+
+        SelectedOption.create(custom_option: custom_option, answer_id: a.id) if custom_option
+      end
+
     end
     head(:created)
   rescue StandardError => e

--- a/backend/app/controllers/survey_answers_controller.rb
+++ b/backend/app/controllers/survey_answers_controller.rb
@@ -2,22 +2,22 @@ class SurveyAnswersController < ApplicationController
   def create
     enrollment = Enrollment.find_by!(member_id: params[:member_id], cclass_id: params[:cclass_id])
     survey_answers = SurveyAnswer.new(enrollment: enrollment, survey_id: params[:survey_id])
-    survey_answers.save!
+    survey_answers.save! if params.require(:answers)
     params.require(:answers).each do |answer|
-      a = Answer.new(answer.permit(:survey_question_id, :content)) #(:selected_options, :custom_option)
+      a = Answer.new(answer.permit(:survey_question_id, :content))
+      a.content = nil if a.survey_question.question_type == 'Caixa de Seleção'
       a.survey_answer_id = survey_answers.id
       a.save!
       if a.survey_question.question_type == 'Caixa de Seleção'
-        options = answer.require(:selected_options).map(&:to_i)
-        custom_option = answer.require(:custom_option)
-
-        options.each do |option|
-          SelectedOption.create(option_id: option, answer_id: a.id)
+        if answer[:selected_options]
+          answer[:selected_options].map(&:to_i).each do |option|
+            SelectedOption.create!(option_id: option, answer_id: a.id)
+          end
         end
 
-        SelectedOption.create(custom_option: custom_option, answer_id: a.id) if custom_option
+        custom_option = answer.permit(:custom_option)[:custom_option]
+        SelectedOption.create!(custom_option: custom_option, answer_id: a.id) if custom_option
       end
-
     end
     head(:created)
   rescue StandardError => e

--- a/backend/app/models/selected_option.rb
+++ b/backend/app/models/selected_option.rb
@@ -1,5 +1,5 @@
 class SelectedOption < ApplicationRecord
-  belongs_to :option, optional: true
+  belongs_to :option, optional: { scope: :custom_option }
   belongs_to :answer
 
   validates :custom_option, presence: true, unless: :option

--- a/backend/app/models/selected_option.rb
+++ b/backend/app/models/selected_option.rb
@@ -1,7 +1,6 @@
 class SelectedOption < ApplicationRecord
-  belongs_to :option
+  belongs_to :option, optional: true
   belongs_to :answer
 
-  validates :custom_option, presence: true
-
+  validates :custom_option, presence: true, unless: :option
 end

--- a/backend/bin/rails
+++ b/backend/bin/rails
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
 APP_PATH = File.expand_path("../config/application", __dir__)
 require_relative "../config/boot"
+if ENV['RAILS_ENV'] == 'test'
+  require 'simplecov'
+  SimpleCov.start 'rails'
+  puts "required simplecov"
+end
 require "rails/commands"

--- a/backend/db/migrate/20220505034547_optional_option_for_seleceted_option.rb
+++ b/backend/db/migrate/20220505034547_optional_option_for_seleceted_option.rb
@@ -1,0 +1,5 @@
+class OptionalOptionForSelecetedOption < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :selected_options, :option_id, true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_24_025437) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_05_034547) do
   create_table "answers", force: :cascade do |t|
     t.text "content"
     t.integer "survey_question_id", null: false
@@ -71,7 +71,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_24_025437) do
 
   create_table "selected_options", force: :cascade do |t|
     t.string "custom_option"
-    t.integer "option_id", null: false
+    t.integer "option_id"
     t.integer "answer_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/backend/spec/requests/survey_answers_spec.rb
+++ b/backend/spec/requests/survey_answers_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe "SurveyAnswers", type: :request do
         post '/survey_answers/create', params: survey_answer_params
       end
 
-      it 'returns bad request' do
+      it 'returns created status' do
         expect(response).to have_http_status(:created)
       end
 
@@ -217,6 +217,25 @@ RSpec.describe "SurveyAnswers", type: :request do
         survey_answers = SurveyAnswer.find_by(enrollment_id: @enrollment.id, survey_id: @survey.id)
         answers = Answer.where(survey_answer_id: survey_answers.id)
         expect(answers.size).to eq(0)
+      end
+    end
+
+    context 'when custom option is not passed' do
+      before do
+        survey_answer_params[:answers].last[:custom_option] = nil
+        post '/survey_answers/create', params: survey_answer_params
+      end
+
+      it 'returns created response' do
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'creates only 2 selected options for selection box answers' do
+        survey_answers = SurveyAnswer.find_by(enrollment_id: @enrollment.id, survey_id: @survey.id)
+        answers = Answer.where(survey_answer_id: survey_answers.id)
+        selection_box_answer = answers.filter { |a| a.survey_question.question_type == 'Caixa de Seleção' }.last
+        selected_options = SelectedOption.where(answer_id: selection_box_answer.id)
+        expect(selected_options.size).to eq(survey_answer_params[:answers].last[:selected_options].size)
       end
     end
   end

--- a/backend/spec/requests/survey_answers_spec.rb
+++ b/backend/spec/requests/survey_answers_spec.rb
@@ -1,7 +1,223 @@
 require 'rails_helper'
 
 RSpec.describe "SurveyAnswers", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  describe "POST /create" do
+    before do
+      subject = Subject.create(code: 'CIC0105', name: 'Engenharia de Software')
+      @cclass = Cclass.create(code: 'TA', semester: '2021.2', time: '35M12', subject: subject)
+      @member = Member.create(name: 'Genaina', course: 'DEPTO CIÊNCIAS DA COMPUTAÇÃO',
+                              registration: '83807519491', username: '83807519491',
+                              degree: 'Doutorado', occupation: 'docente',
+                              email: 'genaina@email.com')
+      @enrollment = Enrollment.create(member: @member, cclass: @cclass)
+      @survey = Survey.create(name: 'Pesquisa Docente sobre o Ensino Remoto', semester: @cclass.semester,
+                              description: 'Para cada disciplina que estiver ministrando, selecione a identificação da disciplina/turma. Julgue os itens seguintes para analisar cada disciplina separadamente. Você poderá analisar até o máximo de 3 disciplinas em que estiver dando aulas.'
+      )
+      @question_1 = SurveyQuestion.create(question_type: "Escala", question: "O plano de ensino entregue foi ajustado", optional: false, survey_id: @survey.id)
+      @question_2 = SurveyQuestion.create(question_type: "Caixa de Seleção", question: "Metodologia de avaliação utilizada", optional: false, survey_id: @survey.id)
+      @option1 = Option.create(option: 'Provas Síncronas', survey_question_id: @question_2.id)
+      @option2 = Option.create(option: 'Provas Assíncronas', survey_question_id: @question_2.id)
+      @option3 = Option.create(option: 'Trabalhos', survey_question_id: @question_2.id)
+    end
+
+    let(:survey_answer_params) do {
+      member_id: @member.id, cclass_id: @cclass.id, survey_id: @survey.id, answers: [{
+                                                                                       survey_question_id: 1,
+                                                                                       content: 2
+                                                                                     },
+                                                                                     {
+                                                                                       survey_question_id: 2,
+                                                                                       content: 'teste',
+                                                                                       selected_options: [1, 2],
+                                                                                       custom_option: "Opção customizada"
+                                                                                     }
+      ]
+    }
+    end
+
+    context 'with valid params' do
+      before do
+        SurveyAnswer.delete_all
+        post '/survey_answers/create', params: survey_answer_params
+      end
+
+      it 'returns a created status' do
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'creates the survey answers' do
+        survey_answers = SurveyAnswer.find_by(enrollment_id: @enrollment.id, survey_id: @survey.id)
+        expect(survey_answers).not_to be nil
+      end
+
+      it 'creates the questions answers' do
+        survey_answers = SurveyAnswer.find_by(enrollment_id: @enrollment.id, survey_id: @survey.id)
+        answers = Answer.where(survey_answer_id: survey_answers.id)
+        expect(answers.size).to eq(survey_answer_params[:answers].size)
+      end
+
+      it 'creates the custom option for selection box answers' do
+        survey_answers = SurveyAnswer.find_by(enrollment_id: @enrollment.id, survey_id: @survey.id)
+        answers = Answer.where(survey_answer_id: survey_answers.id)
+        selection_box_answer = answers.filter { |a| a.survey_question.question_type == 'Caixa de Seleção' }.last
+        custom_option = SelectedOption.where(answer_id: selection_box_answer.id, custom_option: survey_answer_params[:answers].last[:custom_option])
+        expect(custom_option).not_to be nil
+      end
+
+      it 'creates the selected options for selection box answers' do
+        survey_answers = SurveyAnswer.find_by(enrollment_id: @enrollment.id, survey_id: @survey.id)
+        answers = Answer.where(survey_answer_id: survey_answers.id)
+        selection_box_answer = answers.filter { |a| a.survey_question.question_type == 'Caixa de Seleção' }.last
+        selected_options = SelectedOption.where(answer_id: selection_box_answer.id)
+        extra_option = survey_answer_params[:answers].last[:custom_option] ? 1 : 0
+        expect(selected_options.size).to eq(
+                                           survey_answer_params[:answers].last[:selected_options].size +
+                                             extra_option
+                                         )
+      end
+    end
+
+    context 'without survey id' do
+      before do
+        survey_answer_params[:survey_id] = nil
+        SurveyAnswer.delete_all
+        post '/survey_answers/create', params: survey_answer_params
+      end
+
+      it 'returns bad request' do
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'does not create the survey answers' do
+        survey_answers = SurveyAnswer.find_by(enrollment_id: @enrollment.id, survey_id: @survey.id)
+        expect(survey_answers).to be nil
+      end
+    end
+
+    context 'without member id' do
+      before do
+        survey_answer_params[:member_id] = nil
+        SurveyAnswer.delete_all
+        post '/survey_answers/create', params: survey_answer_params
+      end
+
+      it 'returns bad request' do
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'does not create the survey answers' do
+        survey_answers = SurveyAnswer.find_by(enrollment_id: @enrollment.id, survey_id: @survey.id)
+        expect(survey_answers).to be nil
+      end
+    end
+
+    context 'without cclass id' do
+      before do
+        survey_answer_params[:cclass_id] = nil
+        SurveyAnswer.delete_all
+        post '/survey_answers/create', params: survey_answer_params
+      end
+
+      it 'returns bad request' do
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'does not create the survey answers' do
+        survey_answers = SurveyAnswer.find_by(enrollment_id: @enrollment.id, survey_id: @survey.id)
+        expect(survey_answers).to be nil
+      end
+    end
+
+    context 'without answers array' do
+      before do
+        survey_answer_params[:answers] = nil
+        SurveyAnswer.delete_all
+        post '/survey_answers/create', params: survey_answer_params
+      end
+
+      it 'returns bad request' do
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'does not create the survey answers' do
+        survey_answers = SurveyAnswer.find_by(enrollment_id: @enrollment.id, survey_id: @survey.id)
+        expect(survey_answers).to be nil
+      end
+    end
+
+    context 'when answers is not an array' do
+      before do
+        survey_answer_params[:answers] = { }
+        SurveyAnswer.delete_all
+        post '/survey_answers/create', params: survey_answer_params
+      end
+
+      it 'returns bad request' do
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'does not create the survey answers' do
+        survey_answers = SurveyAnswer.find_by(enrollment_id: @enrollment.id, survey_id: @survey.id)
+        expect(survey_answers).to be nil
+      end
+    end
+
+    context 'when selected option does not exist' do
+      before do
+        SurveyAnswer.delete_all
+        Option.delete_all
+        post '/survey_answers/create', params: survey_answer_params
+      end
+
+      it 'returns bad request' do
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'does not create any selected options' do
+        survey_answers = SurveyAnswer.find_by(enrollment_id: @enrollment.id, survey_id: @survey.id)
+        answers = Answer.where(survey_answer_id: survey_answers.id)
+        selection_box_answer = answers.filter { |a| a.survey_question.question_type == 'Caixa de Seleção' }.last
+        selected_options = SelectedOption.where(answer_id: selection_box_answer.id)
+        expect(selected_options.size).to eq(0)
+      end
+    end
+
+    context 'when only custom option is passed' do
+      before do
+        survey_answer_params[:answers].last[:selected_options] = nil
+        post '/survey_answers/create', params: survey_answer_params
+      end
+
+      it 'returns bad request' do
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'creates the custom option for selection box answers' do
+        survey_answers = SurveyAnswer.find_by(enrollment_id: @enrollment.id, survey_id: @survey.id)
+        answers = Answer.where(survey_answer_id: survey_answers.id)
+        selection_box_answer = answers.filter { |a| a.survey_question.question_type == 'Caixa de Seleção' }.last
+        custom_option = SelectedOption.where(answer_id: selection_box_answer.id, custom_option: survey_answer_params[:answers].last[:custom_option])
+        expect(custom_option).not_to be nil
+      end
+    end
+
+    context 'when question does not exist' do
+      before do
+        survey_answer_params[:answers].last[:selected_options] = nil
+        Option.delete_all
+        SurveyQuestion.delete_all
+        post '/survey_answers/create', params: survey_answer_params
+      end
+
+      it 'returns bad request' do
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'does not create answers' do
+        survey_answers = SurveyAnswer.find_by(enrollment_id: @enrollment.id, survey_id: @survey.id)
+        answers = Answer.where(survey_answer_id: survey_answers.id)
+        expect(answers.size).to eq(0)
+      end
+    end
   end
 end

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -13,6 +13,12 @@
 # it.
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+# Simple covery
+
+require 'simplecov'
+SimpleCov.start
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
Closes #12, #21

- Método de criar resposta de questionário agora cria também as Opções selecionadas para opções de caixa de seleção
- option_id e custom_option na selected option agora são opcionais(Precisa de um dos dois, mas não dos dois)
- Muitos testes rspec
- Adicionada a gem Simple coverage e verificando a cobertura dos testes
    - Aparentemente temos 100% de cobertura dos testes (Nem sabia que isso era possível)
![Captura de tela de 2022-05-05 02-05-40](https://user-images.githubusercontent.com/65040370/166866266-84883db9-2f6c-440c-8785-7be12a1aa32c.png)